### PR TITLE
Improve compatibility with other frameworks and future OMF.

### DIFF
--- a/android-sdk.load
+++ b/android-sdk.load
@@ -1,7 +1,0 @@
-if test -n "$ANDROID_SDK_ROOT"
-  _prepend_path $ANDROID_SDK_ROOT/tools
-  _prepend_path $ANDROID_SDK_ROOT/platform-tools
-else
-  _prepend_path /opt/android-sdk/tools
-  _prepend_path /opt/android-sdk/platform-tools
-end

--- a/init.fish
+++ b/init.fish
@@ -1,0 +1,3 @@
+set -q ANDROID_SDK_ROOT; or set -l ANDROID_SDK_ROOT /opt/android-sdk
+
+set PATH $ANDROID_SDK_ROOT/platform-tools $ANDROID_SDK_ROOT/tools $PATH

--- a/init.fish
+++ b/init.fish
@@ -1,3 +1,9 @@
 set -q ANDROID_SDK_ROOT; or set -l ANDROID_SDK_ROOT /opt/android-sdk
 
-set PATH $ANDROID_SDK_ROOT/platform-tools $ANDROID_SDK_ROOT/tools $PATH
+if not contains $ANDROID_SDK_ROOT/tools $PATH
+  set PATH $ANDROID_SDK_ROOT/tools $PATH
+end
+
+if not contains $ANDROID_SDK_ROOT/platform-tools $PATH
+  set PATH $ANDROID_SDK_ROOT/platform-tools $PATH
+end


### PR DESCRIPTION
- Move initialization to `init.fish`, use fishier idioms.
- Only add missing paths during init.
