### PR TITLE
Update code for fish 3.x

### DIFF
--- a/conf.d/android-sdk.fish
+++ b/conf.d/android-sdk.fish
@@ -1,6 +1,7 @@
 set paths $ANDROID_HOME/{tool?,platform-tool?}
-  or set paths $ANDROID_SDK_ROOT/{tool?,platform-tool?}
-  or set paths $HOME/Android/Sdk/{tool?,platform-tool?}
+test -n "$paths"; or set paths $ANDROID_SDK_ROOT/{tool?,platform-tool?}
+test -n "$paths"; or set paths $HOME/Android/Sdk/{tool?,platform-tool?}
+test -n "$paths"; or set paths $HOME/Library/Android/sdk/{tool?,platform-tool?}
 
 if test (count $paths) -gt 0
   set -l IFS /


### PR DESCRIPTION
As of Fish 3.0, set does not send a return code to allow capture of errors in sub commands. This change uses test to verify if the variable is unset instead.